### PR TITLE
Updated sitl instructions to include correct frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If there is not SITL instance attached, these keys can be used to control the RO
 
     Before opening Bluesim (it launches its own SITL instance), run:
 
- `sim_vehicle.py -j6 -L RATBeach --frame JSON --out=udpout:0.0.0.0:14550`
+ `sim_vehicle.py -j6 -L RATBeach -v ArduSub -f vectored_6dof JSON --out=udpout:0.0.0.0:14550`
 
 # External Levels
 


### PR DESCRIPTION
This small update to the readme file, should launch the correct SITL simulation corresponding with the 6DOF bluerov heavy used in the bluesim.
This fixed issue #55 